### PR TITLE
Fix close button position

### DIFF
--- a/pointerplus.css
+++ b/pointerplus.css
@@ -49,5 +49,11 @@
 }
 
 .pp-pointer-content .wp-pointer-buttons .close {
+  position: absolute;
+  right: 10px;
   top:10px;
+}
+
+.pp-pointer-content .wp-pointer-buttons .close:before {
+  color: #FFFFFF
 }


### PR DESCRIPTION
Close button position was being set to the bottom right of the pointer: https://prnt.sc/JSuN6f6xTQy7

P.S Can you please enable `Issues` on the repo...there's no way for someone to report issues...