### PR TITLE
Add dismiss text next to close button

### DIFF
--- a/pointerplus.css
+++ b/pointerplus.css
@@ -49,11 +49,5 @@
 }
 
 .pp-pointer-content .wp-pointer-buttons .close {
-  position: absolute;
-  right: 10px;
   top:10px;
-}
-
-.pp-pointer-content .wp-pointer-buttons .close:before {
-  color: #FFFFFF
 }

--- a/pointerplus.js
+++ b/pointerplus.js
@@ -65,7 +65,7 @@ jQuery(function ($) {
             });
             return button;
           } else {
-            var close = (wpPointerL10n) ? wpPointerL10n.dismiss : 'Dismiss', button = jQuery('<a class="close" href="#">' + close + '</a>');
+            var close = (wpPointerL10n) ? wpPointerL10n.dismiss : 'Dismiss', button = jQuery('<a class="close" href="#">' + close + pointerplus.l10n.dismiss + '</a>');
             return button.bind('click.pointer', function (e) {
               e.preventDefault();
               t.element.pointer('close');

--- a/pointerplus.php
+++ b/pointerplus.php
@@ -136,7 +136,10 @@ class PointerPlus {
             }
         }
     }
-    $this->pointers[ 'l10n' ] = array( 'next' => __( 'Next' ) );
+    $this->pointers[ 'l10n' ] = array( 
+	    'next' => __( 'Next' ),
+	    'dismiss' => __( 'Dismiss' ),
+    );
   }
 
   /**


### PR DESCRIPTION
In my last pull request I moved the close button to the top, which isn't the usual way this is done in WP. After installing a few more plugins that make use of pointers I noticed that it's common to have the close button at the bottom, but the only thing your library seems to be missing is the "Dismiss" text:

![image](https://user-images.githubusercontent.com/10324144/189459427-c61abd35-cee4-4336-8ee9-44b2cbf11e70.png)

In this pull I added it and undid my last change